### PR TITLE
ACQ - Captured name of the user to add in the dashboard header

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -18,8 +18,14 @@ function Dashboard() {
 	const { signOut } = useAuth();
 	const { posts, resetPosts } = usePost();
 	const { Get } = useHttp({ url: 'agenda/post' });
+	const { session } = useAuth();
+	const userName = session.data!.fullName;
 	const params = useRef({ page: 1, limit: 10, count: 1 });
 	const totalPagesCount = Math.ceil(params.current.count / params.current.limit);
+
+	function userNameCapitalized(username: string) {
+		return username.charAt(0).toUpperCase() + username.slice(1);
+	}
 
 	function getPosts(pageNumber?: number) {
 		Get({ params: {...params.current, ...(pageNumber ? {page: pageNumber} : {})}})
@@ -54,7 +60,7 @@ function Dashboard() {
 							alt="user profile picture"
 							src="https://www.mockofun.com/wp-content/uploads/2019/12/circle-profile-pic.jpg"
 						/>
-						<TitleText>Natalie</TitleText>
+						<TitleText>{userNameCapitalized(userName)}</TitleText>
 					</Styled.AvatarContainer>
 					<CustomButton
 						variant="contained"

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -13,6 +13,7 @@ import { usePost } from '@/contexts/post';
 import useHttp from '@/services/useHttp';
 import { useEffect, useRef } from 'react';
 import PaginationRounded from '@/components/pagination';
+import { userNameCapitalized } from '@/utils/userNameCapitalized';
 
 function Dashboard() {
 	const { signOut } = useAuth();
@@ -22,10 +23,6 @@ function Dashboard() {
 	const userName = session.data!.fullName;
 	const params = useRef({ page: 1, limit: 10, count: 1 });
 	const totalPagesCount = Math.ceil(params.current.count / params.current.limit);
-
-	function userNameCapitalized(username: string) {
-		return username.charAt(0).toUpperCase() + username.slice(1);
-	}
 
 	function getPosts(pageNumber?: number) {
 		Get({ params: {...params.current, ...(pageNumber ? {page: pageNumber} : {})}})

--- a/src/components/form/buttons/button/index.tsx
+++ b/src/components/form/buttons/button/index.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { ButtonProps } from '@mui/material';
 import * as Styled from './styles';
 
-const CustomButton = ({ children, ...props }: ButtonProps) => {
+const CustomButton = ({ children, ...props }: Omit<ButtonProps, 'sx' >) => {
 	return (
 		<Styled.CustomButton {...props}>
 			{children}

--- a/src/utils/userNameCapitalized.ts
+++ b/src/utils/userNameCapitalized.ts
@@ -1,0 +1,3 @@
+export function userNameCapitalized(username: string) {
+	return username.charAt(0).toUpperCase() + username.slice(1);
+}


### PR DESCRIPTION
A alteração visa pegar o nome do usuário que está logado e por para ficar exposto no header do dashboard

A solução foi pegar as informações do usuário através do context to de useAuth, pegando a session que contém os dados. Foi criada uma função para por a primeira letra em caixa alta, caso a mesma esteja em caixa baixa.

